### PR TITLE
Use gb as alias

### DIFF
--- a/freja/evaling.janet
+++ b/freja/evaling.janet
@@ -1,6 +1,6 @@
 (import freja/state)
 (import bounded-queue :as queue)
-(import ./new_gap_buffer :as gap)
+(import ./new_gap_buffer :as gb)
 
 (def grammar
   ~{:ws (set " \t\r\f\n\0\v")
@@ -80,7 +80,7 @@ ouae
 (varfn gb-get-last-sexp
   [gb]
   (-> gb
-      gap/commit!
+      gb/commit!
       (get :text)
       (string/slice 0 (gb :caret))
       get-last-sexp))


### PR DESCRIPTION
This PR is a suggestion to use `gb` as an alias as that seems to be what's most often used elsewhere when a shorter name is desired:

```
$ rg import\ ./new_gap_buffer\ :as --sort path
freja/evaling.janet
3:(import ./new_gap_buffer :as gap)

freja/input.janet
4:(import ./new_gap_buffer :as gb)

freja/main.janet
81:(import ./new_gap_buffer :as new_gap_buffer)

freja/render_new_gap_buffer.janet
5:(import ./new_gap_buffer :as gb)

freja/textarea.janet
2:(import ./new_gap_buffer :as gb)
```